### PR TITLE
Replace first occurance of keyBuffer with a 0 to replicate iOS6

### DIFF
--- a/iPhone/Tiqr/Classes/SecretStore.m
+++ b/iPhone/Tiqr/Classes/SecretStore.m
@@ -146,6 +146,10 @@
 
     // fetch key data
     [key getCString:keyBuffer maxLength:sizeof(keyBuffer) encoding:NSASCIIStringEncoding];
+    
+    // iOS getCString truncates keyBuffer to maxLength. and replaces the first character with a 0
+    // To ensure upgrading from iOS6 to 7 works. Do the same.
+    keyBuffer[0] = 0;
 
     // For block ciphers, the output size will always be less than or 
 	// equal to the input size plus the size of one block.
@@ -196,6 +200,10 @@
     
     // fetch key data
     [key getCString:keyBuffer maxLength:sizeof(keyBuffer) encoding:NSUTF8StringEncoding];
+    
+    // iOS getCString truncates keyBuffer to maxLength. and replaces the first character with a 0
+    // To ensure upgrading from iOS6 to 7 works. Do the same.
+    keyBuffer[0] = 0;
     
     // For block ciphers, the output size will always be less than or 
 	// equal to the input size plus the size of one block.


### PR DESCRIPTION
iOS6's getCString:keyBuffer:encoding truncates the string to match maxLength, it also replaces the first character with a 0 instead of keeping it intact. Replicate this behaviour so older keys used remain usable.
